### PR TITLE
Pin compatible scipy versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   skip: true  # [py<39 or win]
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -47,6 +47,7 @@ requirements:
     - python-lalsimulation
     - qnm
     - rich
+    - {{ pin_compatible('scipy') }}
     - scipy >=1.8.0
     - scri
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - nolalsuite-in-pyproject.patch
 
 build:
-  skip: true  # [py<39 or win]
+  skip: true  # [win]
   script: {{ PYTHON }} -m pip install . -vv
   number: 1
 
@@ -40,6 +40,8 @@ requirements:
     - matplotlib-base
     - numba
     - numexpr
+    - {{ pin_compatible('numpy') }}
+    - numpy >=1.23.0
     - pygsl_lite
     - python
     - python-lal
@@ -51,8 +53,6 @@ requirements:
     - scipy >=1.8.0
     - scri
     - setuptools
-    - {{ pin_compatible('numpy') }}
-    - numpy >=1.23.0
 
 test:
   requires:


### PR DESCRIPTION
This PR adds a runtime requirement on `{{ pin_compatible('scipy') }}` to ensure that the runtime package is pinned to versions of scipy that are compatible with the version used in the Cython build.

This should prevent the current situation where 0.2.12 was built against 1.14.x but _can_ be installed at runtime alongside 1.12.x, but immediately fails.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
