### PR TITLE
Disabling the tests on dynamics for the EHM model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/disable_ehm_dynamics_tests.patch
+++ b/recipe/disable_ehm_dynamics_tests.patch
@@ -1,0 +1,23 @@
+diff --git a/test/regression_tests/test_SEOBNRv5EHM.py b/test/regression_tests/test_SEOBNRv5EHM.py
+index c1261454..e023caa5 100644
+--- a/test/regression_tests/test_SEOBNRv5EHM.py
++++ b/test/regression_tests/test_SEOBNRv5EHM.py
+@@ -3,6 +3,7 @@ Test that the aligned-spin eccentric model SEOBNRv5EHM.
+ 
+ """
+ 
++import os
+ from pathlib import Path
+ from unittest import mock
+ 
+@@ -99,6 +100,10 @@ class TestEccentric:
+         assert model_ehm.dynamics is not None
+         p_compute_dynamics_ecc_secular_opt.assert_called_once()
+ 
++    @pytest.mark.skipif(
++        "CI_TEST_DYNAMIC_REGRESSIONS" not in os.environ,
++        reason="regressions on dynamics are for specific systems only",
++    )
+     def test_regression_full_model(self):
+         """Regression tests on the full model"""
+         q = 1.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,14 @@ source:
   patches:
     - nolalsuite-in-pyproject.patch
     - pandas-item-access-in-test.patch
+    - disable_ehm_dynamics_tests.patch
 
 build:
   skip: true  # [win]
   script: |
     find . -name "*.cpp" -delete
     {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Those tests are failing on igwn-testing: disabling them through a patch until the next release. Those tests will remain disabled except on the platforms we use for CI (they are disabled for the other models).
