### PR TITLE
Rebuild against old(est)-compatible scipy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,10 @@
 {% set name = "pyseobnr" %}
 {% set version = "0.3.4" %}
 
+# choose the oldest scipy possible, to maximise compatibility with user environments
+{% set scipy_version = "1.10" %}  # [py<312]
+{% set scipy_version = "1.12" %}  # [py>=312]
+
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -15,7 +19,7 @@ build:
   skip: true  # [win]
   script: |
     {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -23,7 +27,7 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - numpy                                  # [build_platform != target_platform]
-    - scipy                                  # [build_platform != target_platform]
+    - scipy {{ scipy_version }}              # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib("c") }}
@@ -33,7 +37,7 @@ requirements:
     - numpy
     - pip
     - python
-    - scipy
+    - scipy {{ scipy_version }}
     - setuptools
     - setuptools-scm >=3.4.3
     - wheel
@@ -50,7 +54,6 @@ requirements:
     - python-lalsimulation
     - qnm
     - {{ pin_compatible('scipy') }}
-    - scipy >=1.8.0
     - scri
     - setuptools
 


### PR DESCRIPTION
Currently in this feedstock, `pyseobnr` is built against the latest version of scipy, and then has a runtime pin of `scipy >=1.latest,<2.0.0a0`, which is incompatible with many user environments in LVK/IGWN.

This PR updates the recipe to build these packages against an old version of scipy (inside the minimum requirement of `scipy>=1.8.0` to maximise the compatibility with user environments.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
